### PR TITLE
Wait for `SX126X_IRQ_CAD_DONE` flag before Tx

### DIFF
--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -89,8 +89,7 @@ typedef enum {
     STATE_TX,
     STATE_ACK,
     STATE_RX,
-    STATE_CCA_CLEAR,
-    STATE_CCA_BUSY,
+    STATE_CCA,
 } sx126x_state_t;
 
 /**
@@ -127,6 +126,7 @@ struct sx126x {
     bool radio_sleep;                       /**< Radio sleep status */
     sx126x_cad_params_t cad_params;         /**< Radio Channel Activity Detection parametres */
     bool cad_detected;                      /**< Channel Activity Detected Flag*/
+    bool cad_done;                          /**< Channel Activity Detection Done Flag*/
 
     bool ifs        : 1;    /**< if true, the device is currently inside the IFS period */
     bool cca_send   : 1;    /**< whether the next transmission uses CCA or not */

--- a/tests/ieee802154_hal/Makefile
+++ b/tests/ieee802154_hal/Makefile
@@ -19,6 +19,7 @@ BOARD_WHITELIST :=  \
 					pba-d-01-kw2x \
 					rak3172 \
           lora2w \
+          lora-e5-dev \
 					#
 
 DISABLE_MODULE += auto_init_at86rf2xx auto_init_nrf802154 auto_init_sx126x


### PR DESCRIPTION
This makes sure that the device waits for CAD to be done before going to the transmit state.
